### PR TITLE
Fix the error where the code doesn't compile

### DIFF
--- a/src/superagent.d.ts
+++ b/src/superagent.d.ts
@@ -1,0 +1,3 @@
+// Temporary fix
+// REVIEW: Look into a better solution
+declare interface XMLHttpRequest {}


### PR DESCRIPTION
TypeScript is not used for browser development here, hence it does not know the type XMLHttpRequest (used by SuperAgent)
This is not an ideal solution and we should look into a better solution (maybe add the "dom" lib in tsconfig.json)